### PR TITLE
Updated pipeline for node versions being out of date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,9 @@ jobs:
   build-win:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ilammy/msvc-dev-cmd@v1
-      - uses: actions-rs/toolchain@v1
+      - uses: actions-rs/toolchain@v2
         with:
           toolchain: stable
       - run: |
@@ -23,8 +23,8 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v2
         with:
           toolchain: stable
       - run: |
@@ -35,8 +35,8 @@ jobs:
   build-macos:
     runs-on: macOS-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v2
         with:
           toolchain: stable
       - run: |


### PR DESCRIPTION
changed the checkout and rs toolchain to use a newer version, and hopefully resolve node warnings